### PR TITLE
Change default layout to portrait

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -4,7 +4,10 @@ import "strings"
 
 func buildDOTFile() string {
 	g := []byte{}
-	g = append(g, "digraph {\n"...)
+	g = append(g, `
+digraph {
+rankdir="LR"
+`...)
 	for _, s := range structsList {
 		if len(s.Embeds) == 0 {
 			continue


### PR DESCRIPTION
Change the generated graph to [flow from left to right](https://graphviz.org/docs/attrs/rankdir/), rather than top to bottom. This will normally create a graph with less horizontal scrolling. It may be useful to allow users to modify the graph direction with a flag, but for now I think it's a sane default.

Thank you to @dragonly for the suggestion. Closes #4.