### PR TITLE
feat: support exclude pkg config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Usage: embedded-struct-visualizer [OPTIONS] DirToScan
 If the directory to scan is not provided, it defaults to './'
 OPTIONS:
   -out <file>  path to output file (default: write to stdout)
+  -rankdir <direction> graphs direction (default: LR, enum: TB,LR,BT,RL)
+  -exclude-pkg path to exclude pkg config file, format(default: empty):
+     eg: exclude gopkg.in/guregu/null.v3 and models/MyStuct
+       prefix:null.
+       models.MyStuct
   -v           verbose logging
 ```
 

--- a/exclude_pkg.go
+++ b/exclude_pkg.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+func parseExcludeConfig(filename string) error {
+	bs, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(bs), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			excludePkg = append(excludePkg, line)
+		}
+	}
+	return nil
+}
+
+func IsExcludePkg(pkg string) bool {
+	for _, expkg := range excludePkg {
+		if strings.HasPrefix(expkg, "prefix:") {
+			ex := strings.TrimPrefix(expkg, "prefix:")
+			if strings.HasPrefix(pkg, ex) {
+				return true
+			}
+		} else {
+			if expkg == pkg {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/exclude_pkg.go
+++ b/exclude_pkg.go
@@ -20,15 +20,19 @@ func parseExcludeConfig(filename string) error {
 	return nil
 }
 
-func IsExcludePkg(pkg string) bool {
+func IsExcludePkg(structName, pack string) bool {
+	var full = structName
+	if !strings.Contains(structName, ".") {
+		full = pack + "." + structName
+	}
 	for _, expkg := range excludePkg {
 		if strings.HasPrefix(expkg, "prefix:") {
 			ex := strings.TrimPrefix(expkg, "prefix:")
-			if strings.HasPrefix(pkg, ex) {
+			if strings.HasPrefix(full, ex) {
 				return true
 			}
 		} else {
-			if expkg == pkg {
+			if expkg == full {
 				return true
 			}
 		}

--- a/graph.go
+++ b/graph.go
@@ -1,19 +1,26 @@
 package main
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-func buildDOTFile() string {
+func buildDOTFile(rankdir string) string {
 	g := []byte{}
-	g = append(g, `
+
+	g = append(g, fmt.Sprintf(`
 digraph {
-rankdir="LR"
-`...)
+rankdir="%s"
+`, rankdir)...)
 	for _, s := range structsList {
 		if len(s.Embeds) == 0 {
 			continue
 		}
 		g = append(g, getFullStructName(s.Name, s.Package)+" -> { "...)
 		for e := range s.Embeds {
+			if IsExcludePkg(e) {
+				continue
+			}
 			g = append(g, getFullStructName(e, s.Package)+" "...)
 		}
 		g = append(g, "};\n"...)

--- a/graph.go
+++ b/graph.go
@@ -18,7 +18,7 @@ rankdir="%s"
 		}
 		g = append(g, getFullStructName(s.Name, s.Package)+" -> { "...)
 		for e := range s.Embeds {
-			if IsExcludePkg(e) {
+			if IsExcludePkg(e, s.Package) {
 				continue
 			}
 			g = append(g, getFullStructName(e, s.Package)+" "...)

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func help() {
 	fmt.Printf("If the directory to scan is not provided, it defaults to './'\n")
 	fmt.Printf("OPTIONS:\n")
 	fmt.Printf("  -out <file>  path to output file (default: write to stdout)\n")
+	fmt.Printf("  -rankdir <direction> graphs direction (default: LR, enum: TB,LR,BT,RL)\n")
 	fmt.Printf("  -exclude-pkg path to exclude pkg config file, format(default: empty):\n")
 	fmt.Printf("     eg: exclude gopkg.in/guregu/null.v3 and models/MyStuct\n")
 	fmt.Printf("       prefix:null.\n")


### PR DESCRIPTION
1.  the config file sample:

```conf
time.Time
gorm.Model
prefix:null.
```

exclude  `time.Time` , `gorm.Model` and all `gopkg.in/guregu/null.v3`  types
eg: `embedded-struct-visualizer -exclude-pkg ~/exclude-pkg.conf -out 1.dot ./core`

2. add graph direction support